### PR TITLE
Add vitest config and unit tests

### DIFF
--- a/lib/__tests__/dataFunctions.test.ts
+++ b/lib/__tests__/dataFunctions.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest'
+import { getNewsArticle } from '../data'
+
+const mockArticles = [
+  { id: 'a1', title: 't1', date: 'd', excerpt: 'e', content: 'c', image: 'img1', category: 'c1' },
+  { id: 'a2', title: 't2', date: 'd', excerpt: 'e', content: 'c', image: 'img2', category: 'c2' }
+]
+
+beforeAll(() => {
+  process.env.GOOGLE_DRIVE_URL = 'https://example.com'
+  process.env.UNSPLASH_ACCESS_KEY = 'key'
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getNewsArticle', () => {
+  it('returns article matching slug', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockArticles))
+    }))
+    const article = await getNewsArticle('a1')
+    expect(article).toEqual(mockArticles[0])
+  })
+
+  it('returns null when not found', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockArticles))
+    }))
+    const article = await getNewsArticle('unknown')
+    expect(article).toBeNull()
+  })
+})

--- a/lib/__tests__/random_image.test.ts
+++ b/lib/__tests__/random_image.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest'
+
+beforeAll(() => {
+  process.env.UNSPLASH_ACCESS_KEY = 'test'
+  process.env.GOOGLE_DRIVE_URL = 'https://example.com'
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getRandomSeaImage', () => {
+  it('returns image url when fetch succeeds', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ urls: { regular: 'image-url' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { getRandomSeaImage } = await import('../random_image')
+    const url = await getRandomSeaImage()
+    expect(url).toBe('image-url')
+    expect(mockFetch).toHaveBeenCalled()
+  })
+
+  it('returns placeholder when fetch fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const { getRandomSeaImage } = await import('../random_image')
+    const url = await getRandomSeaImage()
+    expect(url).toBe('https://placehold.co/1920x1080')
+  })
+})

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '../utils'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('p-2', 'text-center')).toBe('p-2 text-center')
+  })
+
+  it('dedupes conflicting tailwind classes', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
   test: {
     environment: 'node'
   }


### PR DESCRIPTION
## Summary
- configure Vitest with project alias
- add unit tests for utility helpers, data helpers and Unsplash helper

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68875f0085bc8324b1d031ac0a85a78a